### PR TITLE
Feature/models req without model data

### DIFF
--- a/__tests__/entities/bathingspots.test.ts
+++ b/__tests__/entities/bathingspots.test.ts
@@ -8,7 +8,6 @@ import 'reflect-metadata';
 import request from 'supertest';
 import { Connection } from 'typeorm';
 import routes from '../../src/lib/routes';
-import { DefaultRegions, HttpCodes } from '../../src/lib/common';
 import {
   closeTestingConnections,
   createTestingConnections,

--- a/__tests__/routes/bathingspots/bathingspots-collection.integration.test.ts
+++ b/__tests__/routes/bathingspots/bathingspots-collection.integration.test.ts
@@ -1,33 +1,32 @@
 import { PredictionValue } from './../../../src/lib/common/index';
 import { BathingspotPrediction } from './../../../src/orm/entity/BathingspotPrediction';
-import { Discharge } from './../../../src/orm/entity/Discharge';
 import { GenericInput } from './../../../src/orm/entity/GenericInput';
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
+import { async } from 'rxjs/internal/scheduler/async';
 import request from 'supertest';
 import { Connection } from 'typeorm';
 import routes from '../../../src/lib/routes';
-import path from 'path';
+import {
+  getColletionItemById,
+  getGIWithRelations,
+  getPPlantWithRelations,
+} from '../../../src/lib/utils/collection-repo-helpers';
+import {
+  BathingspotMeasurement,
+  BathingspotModel,
+  Discharge,
+  GlobalIrradiance,
+  PurificationPlant,
+} from '../../../src/orm/entity';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import { async } from 'rxjs/internal/scheduler/async';
-import {
-  getColletionItemById,
-  getPPlantWithRelations,
-  getGIWithRelations,
-} from '../../../src/lib/utils/collection-repo-helpers';
-import {
-  Discharge,
-  GlobalIrradiance,
-  BathingspotModel,
-  BathingspotMeasurement,
-  PurificationPlant,
-} from '../../../src/orm/entity';
 
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
@@ -40,8 +39,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('testing bathingspots collection', () => {
@@ -107,10 +106,10 @@ describe('testing bathingspots collection', () => {
 
   test('route POST users bathingspots collection rains', async (done) => {
     const obj = {
-      value: Math.random() * 10,
-      dateTime: '12:00:01',
-      date: '2019-12-31',
       comment: 'This is a test',
+      date: '2019-12-31',
+      dateTime: '12:00:01',
+      value: Math.random() * 10,
     };
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/rains')
@@ -124,10 +123,10 @@ describe('testing bathingspots collection', () => {
   });
   test('route DELETE users bathingspots collection rains', async (done) => {
     const obj = {
-      value: Math.random() * 10,
-      dateTime: '12:00:01',
-      date: '2019-12-31',
       comment: 'This is a test',
+      date: '2019-12-31',
+      dateTime: '12:00:01',
+      value: Math.random() * 10,
     };
     const resPost = await request(app)
       .post('/api/v1/users/1/bathingspots/1/rains')
@@ -144,10 +143,10 @@ describe('testing bathingspots collection', () => {
   });
   test('route POST users bathingspots collection genericInputs measurements', async (done) => {
     const obj = {
-      value: Math.random() * 10,
-      dateTime: '12:00:01',
-      date: '2019-12-31',
       comment: 'This is a test',
+      date: '2019-12-31',
+      dateTime: '12:00:01',
+      value: Math.random() * 10,
     };
     await request(app)
       .post('/api/v1/users/1/bathingspots/1/genericInputs/')
@@ -239,8 +238,8 @@ describe('testing bathingspots collection', () => {
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/predictions/')
       .send({
-        dateTime: '12:00:00',
         date: '2019-12-31',
+        dateTime: '12:00:00',
         prediction: PredictionValue.ausgezeichnet,
       })
       .set(headers);

--- a/__tests__/routes/bathingspots/bathingspots.integration.test.ts
+++ b/__tests__/routes/bathingspots/bathingspots.integration.test.ts
@@ -1,16 +1,16 @@
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection } from 'typeorm';
-import routes from '../../../src/lib/routes';
 import { DefaultRegions, HttpCodes } from '../../../src/lib/common';
-import path from 'path';
+import routes from '../../../src/lib/routes';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
 
 // ███████╗███████╗████████╗██╗   ██╗██████╗
@@ -24,8 +24,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('testing public bathingspots', () => {

--- a/__tests__/routes/misc.integration.test.ts
+++ b/__tests__/routes/misc.integration.test.ts
@@ -1,16 +1,16 @@
 jest.useFakeTimers();
-import { getUserByIdWithSpots } from './../../src/lib/utils/user-repo-helpers';
 import express, { Application } from 'express';
 import 'reflect-metadata';
 import { Connection } from 'typeorm';
-import routes from '../../src/lib/routes';
 import { DefaultRegions } from '../../src/lib/common';
+import routes from '../../src/lib/routes';
+import { getRegionsList } from '../../src/lib/utils/region-repo-helpers';
 import {
   closeTestingConnections,
   createTestingConnections,
   reloadTestingDatabases,
 } from '../test-utils';
-import { getRegionsList } from '../../src/lib/utils/region-repo-helpers';
+import { getUserByIdWithSpots } from './../../src/lib/utils/user-repo-helpers';
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
 // ███████╗█████╗     ██║   ██║   ██║██████╔╝

--- a/__tests__/routes/regions/region.integration.test.ts
+++ b/__tests__/routes/regions/region.integration.test.ts
@@ -1,18 +1,18 @@
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection } from 'typeorm';
-import routes from '../../../src/lib/routes';
 import { DefaultRegions, HttpCodes } from '../../../src/lib/common';
+import routes from '../../../src/lib/routes';
+import { findByName } from '../../../src/lib/utils/region-repo-helpers';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import path from 'path';
-import { findByName } from '../../../src/lib/utils/region-repo-helpers';
 
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗

--- a/__tests__/routes/users/users.delete.integration.test.ts
+++ b/__tests__/routes/users/users.delete.integration.test.ts
@@ -1,6 +1,7 @@
 import { UserRole } from './../../../src/lib/common';
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection, getRepository } from 'typeorm';
@@ -9,10 +10,9 @@ import { User } from '../../../src/orm/entity/User';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import path from 'path';
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
 // ███████╗█████╗     ██║   ██║   ██║██████╔╝
@@ -24,8 +24,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('testing delete users', () => {

--- a/__tests__/routes/users/users.get.integration.test.ts
+++ b/__tests__/routes/users/users.get.integration.test.ts
@@ -6,15 +6,15 @@ import { Connection, getRepository } from 'typeorm';
 
 import routes from '../../../src/lib/routes';
 
+import path from 'path';
+import { UserRole } from '../../../src/lib/common';
+import { User } from '../../../src/orm/entity/User';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import path from 'path';
-import { User } from '../../../src/orm/entity/User';
-import { UserRole } from '../../../src/lib/common';
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
 // ███████╗█████╗     ██║   ██║   ██║██████╔╝
@@ -91,7 +91,7 @@ describe('testing get users', () => {
     done();
   });
   test('route get users by auth0id', async (done) => {
-    let user = new User();
+    const user = new User();
     const repo = getRepository('user');
     const auth0Id = 'auth0|123456';
     repo.merge(user, {

--- a/__tests__/routes/users/users.post.integration.test.ts
+++ b/__tests__/routes/users/users.post.integration.test.ts
@@ -1,16 +1,16 @@
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection } from 'typeorm';
-import routes from '../../../src/lib/routes';
-import path from 'path';
 import { DefaultRegions, UserRole } from '../../../src/lib/common';
+import routes from '../../../src/lib/routes';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
 
 // ███████╗███████╗████████╗██╗   ██╗██████╗

--- a/__tests__/routes/users/users.put.integration.test.ts
+++ b/__tests__/routes/users/users.put.integration.test.ts
@@ -1,18 +1,17 @@
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection } from 'typeorm';
-import routes from '../../../src/lib/routes';
 import { DefaultRegions, UserRole } from '../../../src/lib/common';
+import routes from '../../../src/lib/routes';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import path from 'path';
-import { User } from '../../../src/orm/entity';
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
 // ███████╗█████╗     ██║   ██║   ██║██████╔╝

--- a/__tests__/routes/users/users.spots.collection.test.ts
+++ b/__tests__/routes/users/users.spots.collection.test.ts
@@ -175,7 +175,7 @@ describe('GET all collection tyoe', () => {
       .get('/api/v1/users/1/bathingspots/1/models')
       .set(headers);
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body.data[0].rmodel)).toBeUndefined();
+    expect(res.body.data[0].rmodel).toBeUndefined();
     done();
   });
 

--- a/__tests__/routes/users/users.spots.collection.test.ts
+++ b/__tests__/routes/users/users.spots.collection.test.ts
@@ -23,8 +23,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('GET all collection tyoe', () => {
@@ -227,22 +227,22 @@ describe('GET all collection tyoe', () => {
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/measurements')
       .send({
-        sicht: 1000000,
-        date: '2000-05-16T00:00:00.000Z',
-        conc_ec: 126000,
-        conc_ec_txt: '126000',
-        oldId: 18,
-        detailId: 344351,
-        conc_ie: 15000,
-        conc_ie_txt: '<15000',
-        temp: 21000,
         algen: false,
-        cb: 720000,
-        sichtTxt: '>100000',
-        tempTxt: '21,00000',
         algenTxt: '',
         bsl: 'B329',
+        cb: 720000,
+        conc_ec: 126000,
+        conc_ec_txt: '126000',
+        conc_ie: 15000,
+        conc_ie_txt: '<15000',
+        date: '2000-05-16T00:00:00.000Z',
+        detailId: 344351,
+        oldId: 18,
+        sicht: 1000000,
+        sichtTxt: '>100000',
         state: 'gruen',
+        temp: 21000,
+        tempTxt: '21,00000',
         wasserqualitaet: 1000,
         wasserqualitaetTxt: 1000,
       })
@@ -255,10 +255,10 @@ describe('GET all collection tyoe', () => {
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/discharges')
       .send({
-        value: 1000,
-        dateTime: '05:23:42',
-        date: '08-Jan-1999',
         comment: 'This is a comment, can be NULL',
+        date: '08-Jan-1999',
+        dateTime: '05:23:42',
+        value: 1000,
       })
       .set(headers);
     expect(res.status).toBe(201);
@@ -269,10 +269,10 @@ describe('GET all collection tyoe', () => {
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/rains')
       .send({
-        value: 1000,
-        dateTime: '05:23:42',
-        date: '08-Jan-1999',
         comment: 'This is a comment, can be NULL',
+        date: '08-Jan-1999',
+        dateTime: '05:23:42',
+        value: 1000,
       })
       .set(headers);
     expect(res.status).toBe(201);
@@ -283,10 +283,10 @@ describe('GET all collection tyoe', () => {
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/globalIrradiances')
       .send({
-        value: 1000,
-        dateTime: '05:23:42',
-        date: '08-Jan-1999',
         comment: 'This is a comment, can be NULL',
+        date: '08-Jan-1999',
+        dateTime: '05:23:42',
+        value: 1000,
       })
       .set(headers);
     expect(res.status).toBe(201);
@@ -297,8 +297,8 @@ describe('GET all collection tyoe', () => {
     const res = await request(app)
       .post('/api/v1/users/1/bathingspots/1/models')
       .send({
-        rmodel: 'string dataaaa',
         comment: 'This is another test',
+        rmodel: 'string dataaaa',
       })
       .set(headers);
     expect(res.status).toBe(201);

--- a/__tests__/routes/users/users.spots.collection.test.ts
+++ b/__tests__/routes/users/users.spots.collection.test.ts
@@ -1,5 +1,6 @@
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection } from 'typeorm';
@@ -7,10 +8,9 @@ import routes from '../../../src/lib/routes';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import path from 'path';
 
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
@@ -155,6 +155,7 @@ describe('GET all collection tyoe', () => {
     expect(Array.isArray(res.body.data)).toBe(true);
     done();
   });
+
   test('route GET user by id spot by id models', async (done) => {
     const res = await request(app)
       .get('/api/v1/users/1/bathingspots/1/models')
@@ -163,6 +164,21 @@ describe('GET all collection tyoe', () => {
     expect(Array.isArray(res.body.data)).toBe(true);
     done();
   });
+
+  test('route GET user by id spot by id models should not have field rmodel', async (done) => {
+    await request(app)
+      .post('/api/v1/users/1/bathingspots/1/models')
+      .send({ rmodel: 'foo bah baz' })
+      .set(headers);
+
+    const res = await request(app)
+      .get('/api/v1/users/1/bathingspots/1/models')
+      .set(headers);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data[0].rmodel)).toBeUndefined();
+    done();
+  });
+
   test('route GET user by id spot by id purificationPlants', async (done) => {
     const res = await request(app)
       .get('/api/v1/users/1/bathingspots/1/purificationPlants')

--- a/__tests__/routes/users/users.spots.delete.integration.test.ts
+++ b/__tests__/routes/users/users.spots.delete.integration.test.ts
@@ -3,15 +3,15 @@ import express, { Application } from 'express';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection, getRepository } from 'typeorm';
+import { UserRole } from '../../../src/lib/common';
 import { ERRORS, SUCCESS, SUGGESTIONS } from '../../../src/lib/messages';
 import routes from '../../../src/lib/routes';
-import { UserRole } from '../../../src/lib/common';
 import { User } from '../../../src/orm/entity/User';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
 
 import path from 'path';

--- a/__tests__/routes/users/users.spots.delete.integration.test.ts
+++ b/__tests__/routes/users/users.spots.delete.integration.test.ts
@@ -27,8 +27,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('testing users/[:userId]/bathingspots/[:spotId] delete', () => {

--- a/__tests__/routes/users/users.spots.get.integration.test.ts
+++ b/__tests__/routes/users/users.spots.get.integration.test.ts
@@ -1,18 +1,18 @@
 import { User } from './../../../src/orm/entity/User';
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection, getRepository } from 'typeorm';
-import routes from '../../../src/lib/routes';
 import { DefaultRegions } from '../../../src/lib/common';
+import routes from '../../../src/lib/routes';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import path from 'path';
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
 // ███████╗█████╗     ██║   ██║   ██║██████╔╝
@@ -24,8 +24,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('testing users/[:userId]/bathingspots/[:spotId]', () => {

--- a/__tests__/routes/users/users.spots.post.integration.test.ts
+++ b/__tests__/routes/users/users.spots.post.integration.test.ts
@@ -1,22 +1,22 @@
 import { HttpCodes } from './../../../src/lib/common';
 jest.useFakeTimers();
 import express, { Application } from 'express';
+import path from 'path';
 import 'reflect-metadata';
 import request from 'supertest';
 import { Connection, getRepository } from 'typeorm';
+import { DefaultRegions, UserRole } from '../../../src/lib/common';
 import { ERRORS, SUGGESTIONS } from '../../../src/lib/messages';
 import routes from '../../../src/lib/routes';
-import { DefaultRegions, UserRole } from '../../../src/lib/common';
+import { getUsersByRole } from '../../../src/lib/utils/user-repo-helpers';
 import { Bathingspot } from '../../../src/orm/entity/Bathingspot';
 import { User } from '../../../src/orm/entity/User';
-import path from 'path';
 import {
   closeTestingConnections,
   createTestingConnections,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
-import { getUsersByRole } from '../../../src/lib/utils/user-repo-helpers';
 
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗

--- a/__tests__/routes/users/users.spots.put.integration.test.ts
+++ b/__tests__/routes/users/users.spots.put.integration.test.ts
@@ -12,8 +12,8 @@ import {
   closeTestingConnections,
   createTestingConnections,
   readFileAsync,
-  reloadTestingDatabases,
   readTokenFromDisc,
+  reloadTestingDatabases,
 } from '../../test-utils';
 // ███████╗███████╗████████╗██╗   ██╗██████╗
 // ██╔════╝██╔════╝╚══██╔══╝██║   ██║██╔══██╗
@@ -26,8 +26,8 @@ const token = readTokenFromDisc(
   path.resolve(__dirname, '../../.test.token.json'),
 );
 const headers = {
-  authorization: `${token.token_type} ${token.access_token}`,
   Accept: 'application/json',
+  authorization: `${token.token_type} ${token.access_token}`,
 };
 
 describe('testing users/bathingspot PUT', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flusshygiene-postgres-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flusshygiene-postgres-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/utils/collection-repo-helpers.ts
+++ b/src/lib/utils/collection-repo-helpers.ts
@@ -71,9 +71,18 @@ export const getColletionItemById: (
     const repo = getRepository(repoName);
     // console.log(repo);
 
-    const query = repo
-      .createQueryBuilder(repoName)
-      .where(`${repoName}.id = :itemId`, { itemId });
+    let query;
+    if (repoName === 'BathingspotModel') {
+      query = repo
+        .createQueryBuilder(repoName)
+        .where(`${repoName}.id = :itemId`, { itemId })
+        .addSelect(`${repoName}.rmodel`)
+        .addSelect(`${repoName}.rmodelBinary`);
+    } else {
+      query = repo
+        .createQueryBuilder(repoName)
+        .where(`${repoName}.id = :itemId`, { itemId });
+    }
 
     const entity = await query.getOne();
     switch (repoName) {

--- a/src/orm/entity/BathingspotModel.ts
+++ b/src/orm/entity/BathingspotModel.ts
@@ -23,10 +23,10 @@ export class BathingspotModel {
   @UpdateDateColumn()
   public updatedAt!: Date;
 
-  @Column({ type: 'text', nullable: true })
+  @Column({ type: 'text', nullable: true, select: false })
   public rmodel!: string;
 
-  @Column({ type: 'bytea', nullable: true })
+  @Column({ type: 'bytea', nullable: true, select: false })
   public rmodelBinary!: Buffer;
 
   @Column({ type: 'text', nullable: true })


### PR DESCRIPTION
This PR excludes rmodel text and binary data from selection by calling 

`/bathingspot/{ID}/models`

They only get included when querying for a specif model by id

`/bathingspot/{ID}/models/{ID}`

close #114 